### PR TITLE
Fix stop adding dup rooms

### DIFF
--- a/public/client/app.js
+++ b/public/client/app.js
@@ -127,6 +127,7 @@ function addCreateRoomListener() {
   createRoomForm.addEventListener('submit', (e) => {
     e.preventDefault();
     const newRoom = e.target.roomName.value;
+    e.target.roomName.value = '';
     socket.emit('create-room', {currentRoom: currentRoom, newRoom: newRoom});
     currentRoom = newRoom;
     currentRoomDisplay.innerHTML = `Current Room ${currentRoom}`;

--- a/server/server.js
+++ b/server/server.js
@@ -48,12 +48,15 @@ io.on('connection', async (socket) => {
     socket.join(rooms.newRoom);
     console.log(`${socket.id} joined room ${rooms.newRoom}`);
 
-    const newQueue = new MusicQueue(rooms.newRoom);
-    queueList.push(newQueue);
-
-    io.sockets.emit('room-list', getRoomList());
-
-    io.to(socket.id).emit('update-queue', newQueue);
+    const oldQueue = queueList.find( q => q.queueName === rooms.newRoom);
+    if(!oldQueue) {
+      const newQueue = new MusicQueue(rooms.newRoom);
+      queueList.push(newQueue);
+      io.sockets.emit('room-list', getRoomList());
+      io.to(socket.id).emit('update-queue', newQueue);
+    } else {
+      io.to(socket.id).emit('update-queue', oldQueue);
+    }
   });
 
   // when a user joins, send them that rooms queue and current song


### PR DESCRIPTION
Clicking on create room with the same name twice can add multiple rooms.
This prevents rooms from being added if one already has the same name, and 
instead just join the existing room with the same name.